### PR TITLE
Live with `babel` lib, #10

### DIFF
--- a/doc/latex/pgf-pie/pgf-pie-manual.tex
+++ b/doc/latex/pgf-pie/pgf-pie-manual.tex
@@ -5,7 +5,7 @@
 \documentclass{ltxdoc}
 
 \usepackage{pgf-pie}
-\usetikzlibrary{shadows}
+\usetikzlibrary{babel, shadows}
 
 \usepackage[a4paper,left=2.25cm,right=2.25cm,top=2.5cm,bottom=2.5cm,nohead]{geometry}
 \usepackage{calc}

--- a/tex/latex/pgf-pie/tikzlibrarypie.code.tex
+++ b/tex/latex/pgf-pie/tikzlibrarypie.code.tex
@@ -205,6 +205,10 @@
 }
 
 \def\pgfpie@@pie[#1]#2{%
+  \begingroup
+  % to be compatible with "babel" lib
+  \tikzset{handle active characters in nodes=false}
+
   % load default parameters
   \pgfqkeys{/pgfpie}{
     explode=0,
@@ -280,6 +284,7 @@
     \pgfpie@iflegend{%
       \pgfpie@legend{#2}%
   }{}}%
+  \endgroup
 }
 
 \def\pgfpie@pie@square#1{%

--- a/tex/latex/pgf-pie/tikzlibrarypie.code.tex
+++ b/tex/latex/pgf-pie/tikzlibrarypie.code.tex
@@ -154,15 +154,26 @@
 \newcount\pgfpie@sliceLength
 
 \pgfqkeys{/pgfpie}{%
+  .search also={/tikz,/pgf},
   explode/.store in=\pgfpie@explode,
   color/.store in=\pgfpie@color,
   radius/.store in=\pgfpie@radius,
   pos/.store in=\pgfpie@pos,
   style/.store in=\pgfpie@style,
   before number/.store in=\pgfpie@beforenumber,
-  after number/.store in=\pgfpie@afternumber,
+  after number/.code={%
+    \def\pgfpie@afternumber{#1}%
+    \def\pgfpie@late@afternumber{}%
+  },
   text/.store in=\pgfpie@text,
-  sum/.store in=\pgfpie@sum,
+  sum/.code={%
+    \def\pgfpie@sum{#1}%
+    \pgfpie@ifx\pgfpie@sum\pgfpie@sum@c{%
+      \def\pgfpie@late@afternumber{\def\pgfpie@afternumber{\%}}%
+    }{%
+      \def\pgfpie@late@afternumber{}%
+    }%
+  },
   rotate/.store in=\pgfpie@rotate,
 }
 
@@ -205,12 +216,11 @@
 }
 
 \def\pgfpie@@pie[#1]#2{%
-  \begingroup
-  % to be compatible with "babel" lib
-  \tikzset{handle active characters in nodes=false}
-
-  % load default parameters
-  \pgfqkeys{/pgfpie}{
+  \scope[%
+    % to be compatible with "babel" lib
+    handle active characters in nodes=false,
+    % load default parameters
+    /pgfpie/.cd,
     explode=0,
     color={blue!60, cyan!60, yellow!60, orange!60, red!60,
       blue!60!cyan!60, cyan!60!yellow!60, red!60!cyan!60,
@@ -230,14 +240,11 @@
     hide number=false,
     hide label=false,
     every pie/.try,
-  }%
-  % load user's parameters
-  \pgfqkeys{/pgfpie}{#1}%
+    % load user's parameters
+    #1]
+
   % add percentage automatically
-  \pgfpie@ifx\pgfpie@sum\pgfpie@sum@c{%
-    \pgfqkeys{/pgfpie}{after number=\%}%
-    \pgfqkeys{/pgfpie}{#1}%
-  }{}%
+  \pgfpie@late@afternumber
 
   % legend or not
   \pgfpie@ifx\pgfpie@text\pgfpie@text@legend{%
@@ -284,7 +291,7 @@
     \pgfpie@iflegend{%
       \pgfpie@legend{#2}%
   }{}}%
-  \endgroup
+  \endscope
 }
 
 \def\pgfpie@pie@square#1{%


### PR DESCRIPTION
<s>In order to be compatible with tikz lib `babel`, which will `\scantokens` the node text.</s>

Following [henri's suggestion](https://github.com/pgf-tikz/pgf-pie/pull/11#pullrequestreview-701440949), now the entire pie is put in a group with `handle active characters in nodes=false` applied.

To do some (in-complete) tests, lib `babel` is loaded in package manual.

Fixes #10 