### PR TITLE
Add option "change direction"

### DIFF
--- a/doc/latex/pgf-pie/demo/change-direction.tex
+++ b/doc/latex/pgf-pie/demo/change-direction.tex
@@ -1,0 +1,5 @@
+\begin{tikzpicture}
+  \pie[radius=2]{10/A, 20/B, 30/C, 40/D}
+
+  \pie[pos={6,0}, change direction, radius=2]{10/A, 20/B, 30/C, 40/D}
+\end{tikzpicture}

--- a/doc/latex/pgf-pie/pgf-pie-manual.tex
+++ b/doc/latex/pgf-pie/pgf-pie-manual.tex
@@ -103,6 +103,11 @@ number value and |sum|.
 
 \codeexample[scale=0.4,from file={demo/sum.tex}]
 
+\subsection{Slice order}
+The slices order direction can be set to clockwise by setting |change direction|, default is counterclockwise.
+
+\codeexample[scale=0.4,from file={demo/change-direction.tex}]
+
 \subsection{Text}
 
 \subsubsection{Number}

--- a/tex/latex/pgf-pie/tikzlibrarypie.code.tex
+++ b/tex/latex/pgf-pie/tikzlibrarypie.code.tex
@@ -96,10 +96,25 @@
   }%
 }
 
-\def\pgfpie@findColor#1{%
-  \pgfmathparse{int(mod(#1,\the\pgfpie@colorLength))}%
+\def\pgfpie@findColor#1#2{%
+  \pgfmathparse{int(mod(#2,\the\pgfpie@colorLength))}%
   \let\pgfpie@ci\pgfmathresult
-  \foreach \pgfpie@c [count=\pgfpie@j from 0] in \pgfpie@color {%
+  
+  \ifodd#1 {
+    \let\pgfpie@colorlist\empty
+    \foreach\x in \pgfpie@color {
+      \ifx\pgfpie@colorlist\empty
+        \xdef\pgfpie@colorlist{\x}%
+      \else
+        \xdef\pgfpie@colorlist{\x,\pgfpie@colorlist}%
+      \fi
+    }
+  }
+  \else
+    \xdef\pgfpie@colorlist{\pgfpie@color}%
+  \fi
+  
+  \foreach \pgfpie@c [count=\pgfpie@j from 0] in \pgfpie@colorlist {%
     \pgfpie@ifnum{\pgfpie@j}{=}{\pgfpie@ci}{%
       \xdef\pgfpie@thecolor{\pgfpie@c}%
       \breakforeach
@@ -171,6 +186,9 @@
 
 \pgfpie@newif{legend}
 
+\pgfpie@newif{changedirection}
+\pgfqkeys{/pgfpie}{change direction/.is if=pgfpie@changedirection}
+
 \pgfpie@newif{square}
 \pgfqkeys{/pgfpie}{square/.is if=pgfpie@square}
 
@@ -219,6 +237,7 @@
     text=label,
     sum=100,
     rotate=0,
+    change direction=false,
     polar=false,
     square=false,
     cloud=false,
@@ -293,7 +312,7 @@
   % drawing loop
   \foreach \pgfpie@p/\pgfpie@t [count=\pgfpie@i from 0] in {#1}
   {
-    \pgfpie@findColor{\pgfpie@i}
+    \pgfpie@findColor{0}{\pgfpie@i}
 
     \pgfpie@ifdim{\pgfpie@verticalLength cm}{>}{\pgfpie@horizontalLength cm}{%
       \pgfmathparse{(\pgfpie@p) * (\pgfpie@squareUnit) / (\pgfpie@horizontalLength)}
@@ -384,7 +403,7 @@
     }}%
 
     % find color
-    \pgfpie@findColor{\pgfpie@i}
+    \pgfpie@findColor{0}{\pgfpie@i}
 
     \pgfpie@cloud{pgfpie@O}{\pgfpie@cloudR}{\pgfpie@p}
     {\pgfpie@thecolor}{\pgfpie@style}{\pgfpie@t}
@@ -420,7 +439,20 @@
 
   \xdef\pgfpie@angleBegin{\the\pgfpie@angleEnd}
   % drawing loop
-  \foreach \pgfpie@p/\pgfpie@t [count=\pgfpie@i from 0] in {#1}
+  
+  \pgfpie@ifchangedirection{
+    \let\pgfpie@rlist\empty
+    \foreach\x in {#1} {
+      \ifx\pgfpie@rlist\empty
+        \xdef\pgfpie@rlist{\x}%
+      \else
+        \xdef\pgfpie@rlist{\x,\pgfpie@rlist}%
+      \fi
+    }
+  }
+  {\xdef\pgfpie@rlist{#1}}
+  
+  \foreach \pgfpie@p/\pgfpie@t [count=\pgfpie@i from 0] in \pgfpie@rlist %{#1}
   {
     \pgfmathsetlength{\pgfpie@angleEnd}{\pgfpie@angleBegin}
     \pgfpie@ifpolar{%
@@ -437,7 +469,7 @@
     \pgfpie@findExplode{\pgfpie@i}
 
     % find color
-    \pgfpie@findColor{\pgfpie@i}
+    \pgfpie@ifchangedirection{\pgfpie@findColor{1}{\pgfpie@i}}{\pgfpie@findColor{0}{\pgfpie@i}}    
     \pgfpie@slice{(\pgfpie@angleBegin)/(\pgfpie@sum)*360+(\pgfpie@rotate)}
     {\the\pgfpie@angleEnd/(\pgfpie@sum)*360+(\pgfpie@rotate)}
     {\pgfpie@p}
@@ -458,7 +490,7 @@
   \scope[node distance=0.5cm]
     \foreach \pgfpie@p/\pgfpie@t [count=\pgfpie@i from 0] in {#1}
     {
-      \pgfpie@findColor{\pgfpie@i}
+      \pgfpie@findColor{0}{\pgfpie@i}
       \node[draw, fill={\pgfpie@thecolor}, \pgfpie@style, below of={pgfpie@legendpos}, label={0:{\pgfpie@t}}] (pgfpie@legendpos) {};
     }
   \endscope

--- a/tex/latex/pgf-pie/tikzlibrarypie.code.tex
+++ b/tex/latex/pgf-pie/tikzlibrarypie.code.tex
@@ -439,12 +439,10 @@
     \xdef\pgfpie@theradius{\pgfpie@radius}%
   }
 
-
   \pgfpie@ifchangedirection{%
     \pgfmathsetlength{\pgfpie@angleEnd}{\pgfpie@sum}
   }{}%
   \xdef\pgfpie@angleBegin{\the\pgfpie@angleEnd}
-
   % drawing loop
   \foreach \pgfpie@p/\pgfpie@t [count=\pgfpie@i from 0] in {#1}
   {
@@ -462,7 +460,6 @@
             \pgfmathaddtolength{\pgfpie@angleEnd}{\pgfpie@p}
         }%
     }%
-
 
     % find explode
     \pgfpie@findExplode{\pgfpie@i}

--- a/tex/latex/pgf-pie/tikzlibrarypie.code.tex
+++ b/tex/latex/pgf-pie/tikzlibrarypie.code.tex
@@ -73,7 +73,12 @@
   % slice
   \draw[line join=round,fill={#6},\pgfpie@style] (pgfpie@O) -- ++({#1}:{#7}) arc ({#1}:{#2}:{#7}) -- cycle;
 
-  \pgfmathparse{min(((#2)-(#1)-10)/110*(-0.3),0)}
+  \pgfpie@ifchangedirection{%
+    \pgfmathparse{min(((#1)-(#2)-10)/110*(-0.3),0)}
+  }{%
+    \pgfmathparse{min(((#2)-(#1)-10)/110*(-0.3),0)}
+  }%
+  
   \pgfmathparse{(max(\pgfmathresult,-0.5) + 0.8)*(#7)}
   \let\pgfpie@innerpos\pgfmathresult
 
@@ -434,7 +439,12 @@
     \xdef\pgfpie@theradius{\pgfpie@radius}%
   }
 
+
+  \pgfpie@ifchangedirection{%
+    \pgfmathsetlength{\pgfpie@angleEnd}{\pgfpie@sum}
+  }{}%
   \xdef\pgfpie@angleBegin{\the\pgfpie@angleEnd}
+
   % drawing loop
   \foreach \pgfpie@p/\pgfpie@t [count=\pgfpie@i from 0] in {#1}
   {
@@ -453,24 +463,14 @@
         }%
     }%
 
+
     % find explode
     \pgfpie@findExplode{\pgfpie@i}
 
     % find color
     \pgfpie@findColor{\pgfpie@i}
-    \pgfpie@slice{
-        \pgfpie@ifchangedirection{%
-            (\pgfpie@angleBegin)/(\pgfpie@sum)*360+(\pgfpie@rotate)+360
-        }{%
-            (\pgfpie@angleBegin)/(\pgfpie@sum)*360+(\pgfpie@rotate)
-        }%
-    }%
-    {\pgfpie@ifchangedirection{%
-        \the\pgfpie@angleEnd/(\pgfpie@sum)*360+(\pgfpie@rotate)+360
-        }{%
-        \the\pgfpie@angleEnd/(\pgfpie@sum)*360+(\pgfpie@rotate)
-        }%
-    }%
+    \pgfpie@slice{(\pgfpie@angleBegin)/(\pgfpie@sum)*360+(\pgfpie@rotate)}
+    {\the\pgfpie@angleEnd/(\pgfpie@sum)*360+(\pgfpie@rotate)}
     {\pgfpie@p}
     {\pgfpie@t}
     {\pgfpie@theexplode}
@@ -483,7 +483,8 @@
 
 \def\pgfpie@legend#1{%
   \coordinate[xshift=0.8cm,
-  yshift={(\the\pgfpie@sliceLength*0.5+1)*0.5cm}] (pgfpie@legendpos) at
+  yshift={(\the\pgfpie@sliceLength*0.5+1)*0.5cm}] 
+  (pgfpie@legendpos) at
   (current bounding box.east);
 
   \scope[node distance=0.5cm]

--- a/tex/latex/pgf-pie/tikzlibrarypie.code.tex
+++ b/tex/latex/pgf-pie/tikzlibrarypie.code.tex
@@ -100,19 +100,18 @@
   \pgfmathparse{int(mod(#2,\the\pgfpie@colorLength))}%
   \let\pgfpie@ci\pgfmathresult
   
-  \ifodd#1 {
+  \pgfpie@ifodd{#1}{%
     \let\pgfpie@colorlist\empty
-    \foreach\x in \pgfpie@color {
-      \ifx\pgfpie@colorlist\empty
+    \foreach\x in \pgfpie@color {%
+      \pgfpie@ifx\pgfpie@colorlist\pgfutil@empty{%
         \xdef\pgfpie@colorlist{\x}%
-      \else
+      }{%
         \xdef\pgfpie@colorlist{\x,\pgfpie@colorlist}%
-      \fi
-    }
-  }
-  \else
+      }%
+    }%
+  }{%
     \xdef\pgfpie@colorlist{\pgfpie@color}%
-  \fi
+  }%
   
   \foreach \pgfpie@c [count=\pgfpie@j from 0] in \pgfpie@colorlist {%
     \pgfpie@ifnum{\pgfpie@j}{=}{\pgfpie@ci}{%
@@ -440,17 +439,17 @@
   \xdef\pgfpie@angleBegin{\the\pgfpie@angleEnd}
   % drawing loop
   
-  \pgfpie@ifchangedirection{
+  \pgfpie@ifchangedirection{%
     \let\pgfpie@rlist\empty
     \foreach\x in {#1} {
-      \ifx\pgfpie@rlist\empty
+      \pgfpie@ifx\pgfpie@rlist\pgfutil@empty{%
         \xdef\pgfpie@rlist{\x}%
-      \else
+      }{%
         \xdef\pgfpie@rlist{\x,\pgfpie@rlist}%
-      \fi
-    }
-  }
-  {\xdef\pgfpie@rlist{#1}}
+      }%
+    }%
+  }%
+  {\xdef\pgfpie@rlist{#1}}%
   
   \foreach \pgfpie@p/\pgfpie@t [count=\pgfpie@i from 0] in \pgfpie@rlist %{#1}
   {

--- a/tex/latex/pgf-pie/tikzlibrarypie.code.tex
+++ b/tex/latex/pgf-pie/tikzlibrarypie.code.tex
@@ -480,8 +480,7 @@
 
 \def\pgfpie@legend#1{%
   \coordinate[xshift=0.8cm,
-  yshift={(\the\pgfpie@sliceLength*0.5+1)*0.5cm}] 
-  (pgfpie@legendpos) at
+  yshift={(\the\pgfpie@sliceLength*0.5+1)*0.5cm}] (pgfpie@legendpos) at
   (current bounding box.east);
 
   \scope[node distance=0.5cm]

--- a/tex/latex/pgf-pie/tikzlibrarypie.code.tex
+++ b/tex/latex/pgf-pie/tikzlibrarypie.code.tex
@@ -453,12 +453,12 @@
       \pgfmathparse{sqrt(\pgfpie@p) * (\pgfpie@polarRadiusUnit)}
       \xdef\pgfpie@theradius{\pgfmathresult}
     }{%
-        % normal pie
-        \pgfpie@ifchangedirection{%
-            \pgfmathaddtolength{\pgfpie@angleEnd}{-\pgfpie@p}
-        }{%
-            \pgfmathaddtolength{\pgfpie@angleEnd}{\pgfpie@p}
-        }%
+      % normal pie
+      \pgfpie@ifchangedirection{%
+        \pgfmathaddtolength{\pgfpie@angleEnd}{-(\pgfpie@p)}
+      }{%
+        \pgfmathaddtolength{\pgfpie@angleEnd}{\pgfpie@p}
+      }%
     }%
 
     % find explode

--- a/tex/latex/pgf-pie/tikzlibrarypie.code.tex
+++ b/tex/latex/pgf-pie/tikzlibrarypie.code.tex
@@ -96,24 +96,10 @@
   }%
 }
 
-\def\pgfpie@findColor#1#2{%
-  \pgfmathparse{int(mod(#2,\the\pgfpie@colorLength))}%
+\def\pgfpie@findColor#1{%
+  \pgfmathparse{int(mod(#1,\the\pgfpie@colorLength))}%
   \let\pgfpie@ci\pgfmathresult
-  
-  \pgfpie@ifodd{#1}{%
-    \let\pgfpie@colorlist\empty
-    \foreach\x in \pgfpie@color {%
-      \pgfpie@ifx\pgfpie@colorlist\pgfutil@empty{%
-        \xdef\pgfpie@colorlist{\x}%
-      }{%
-        \xdef\pgfpie@colorlist{\x,\pgfpie@colorlist}%
-      }%
-    }%
-  }{%
-    \xdef\pgfpie@colorlist{\pgfpie@color}%
-  }%
-  
-  \foreach \pgfpie@c [count=\pgfpie@j from 0] in \pgfpie@colorlist {%
+  \foreach \pgfpie@c [count=\pgfpie@j from 0] in \pgfpie@color {%
     \pgfpie@ifnum{\pgfpie@j}{=}{\pgfpie@ci}{%
       \xdef\pgfpie@thecolor{\pgfpie@c}%
       \breakforeach
@@ -323,7 +309,7 @@
   % drawing loop
   \foreach \pgfpie@p/\pgfpie@t [count=\pgfpie@i from 0] in {#1}
   {
-    \pgfpie@findColor{0}{\pgfpie@i}
+    \pgfpie@findColor{\pgfpie@i}
 
     \pgfpie@ifdim{\pgfpie@verticalLength cm}{>}{\pgfpie@horizontalLength cm}{%
       \pgfmathparse{(\pgfpie@p) * (\pgfpie@squareUnit) / (\pgfpie@horizontalLength)}
@@ -414,7 +400,7 @@
     }}%
 
     % find color
-    \pgfpie@findColor{0}{\pgfpie@i}
+    \pgfpie@findColor{\pgfpie@i}
 
     \pgfpie@cloud{pgfpie@O}{\pgfpie@cloudR}{\pgfpie@p}
     {\pgfpie@thecolor}{\pgfpie@style}{\pgfpie@t}
@@ -450,20 +436,7 @@
 
   \xdef\pgfpie@angleBegin{\the\pgfpie@angleEnd}
   % drawing loop
-  
-  \pgfpie@ifchangedirection{%
-    \let\pgfpie@rlist\empty
-    \foreach\x in {#1} {
-      \pgfpie@ifx\pgfpie@rlist\pgfutil@empty{%
-        \xdef\pgfpie@rlist{\x}%
-      }{%
-        \xdef\pgfpie@rlist{\x,\pgfpie@rlist}%
-      }%
-    }%
-  }%
-  {\xdef\pgfpie@rlist{#1}}%
-  
-  \foreach \pgfpie@p/\pgfpie@t [count=\pgfpie@i from 0] in \pgfpie@rlist %{#1}
+  \foreach \pgfpie@p/\pgfpie@t [count=\pgfpie@i from 0] in {#1}
   {
     \pgfmathsetlength{\pgfpie@angleEnd}{\pgfpie@angleBegin}
     \pgfpie@ifpolar{%
@@ -472,17 +445,32 @@
       \pgfmathparse{sqrt(\pgfpie@p) * (\pgfpie@polarRadiusUnit)}
       \xdef\pgfpie@theradius{\pgfmathresult}
     }{%
-    % normal pie
-    \pgfmathaddtolength{\pgfpie@angleEnd}{\pgfpie@p}
-    }
+        % normal pie
+        \pgfpie@ifchangedirection{%
+            \pgfmathaddtolength{\pgfpie@angleEnd}{-\pgfpie@p}
+        }{%
+            \pgfmathaddtolength{\pgfpie@angleEnd}{\pgfpie@p}
+        }%
+    }%
 
     % find explode
     \pgfpie@findExplode{\pgfpie@i}
 
     % find color
-    \pgfpie@ifchangedirection{\pgfpie@findColor{1}{\pgfpie@i}}{\pgfpie@findColor{0}{\pgfpie@i}}    
-    \pgfpie@slice{(\pgfpie@angleBegin)/(\pgfpie@sum)*360+(\pgfpie@rotate)}
-    {\the\pgfpie@angleEnd/(\pgfpie@sum)*360+(\pgfpie@rotate)}
+    \pgfpie@findColor{\pgfpie@i}
+    \pgfpie@slice{
+        \pgfpie@ifchangedirection{%
+            (\pgfpie@angleBegin)/(\pgfpie@sum)*360+(\pgfpie@rotate)+360
+        }{%
+            (\pgfpie@angleBegin)/(\pgfpie@sum)*360+(\pgfpie@rotate)
+        }%
+    }%
+    {\pgfpie@ifchangedirection{%
+        \the\pgfpie@angleEnd/(\pgfpie@sum)*360+(\pgfpie@rotate)+360
+        }{%
+        \the\pgfpie@angleEnd/(\pgfpie@sum)*360+(\pgfpie@rotate)
+        }%
+    }%
     {\pgfpie@p}
     {\pgfpie@t}
     {\pgfpie@theexplode}
@@ -501,7 +489,7 @@
   \scope[node distance=0.5cm]
     \foreach \pgfpie@p/\pgfpie@t [count=\pgfpie@i from 0] in {#1}
     {
-      \pgfpie@findColor{0}{\pgfpie@i}
+      \pgfpie@findColor{\pgfpie@i}
       \node[draw, fill={\pgfpie@thecolor}, \pgfpie@style, below of={pgfpie@legendpos}, label={0:{\pgfpie@t}}] (pgfpie@legendpos) {};
     }
   \endscope


### PR DESCRIPTION
New Try, different solution.

- Rows 76 to 81 are to correct the position of the numbers
- Row 442 to 444 are more or less optional, it seems that pgf/tikz slice wokrs with negative angle but to avoid possible failures this lines set the endangle to the sum. Therefore the angle will not be negative
- Row 456 to 462 is where the direction change is happen because of the substraction and therefore going the other way around the circle

Example calculation with set 25, 25, 30, 20:
First with "normal" rotation
Second with changed rotation and negative angle
Third with changed rotation and fixed starting point

slice | begin | begin angle | end | end angle
-- | -- | -- | -- | --
1 | 0 | 0 | 25 | 90
2 | 25 | 90 | 50 | 180
3 | 50 | 180 | 70 | 252
4 | 70 | 252 | 100 | 360
  |   |   |   |  
1 | 0 | 0 | -25 | -90
2 | -25 | -90 | -50 | -180
3 | -50 | -180 | -70 | -252
4 | -70 | -252 | -100 | -360
  |   |   |   |  
1 | 100 | 360 | 75 | 270
2 | 75 | 270 | 50 | 180
3 | 50 | 180 | 30 | 108
4 | 30 | 108 | 0 | 0


